### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -75,17 +75,17 @@ fn main() {
 
     generate_binding(libhs.include_paths[0].to_str().unwrap(), &out_file);
 
-    if cfg!(target_os = "macos") {
-        println!("cargo:rustc-link-lib=dylib=c++");
-    } else {
-        println!("cargo:rustc-link-lib=dylib=stdc++");
-        println!("cargo:rustc-link-lib=dylib=gcc");
-    }
-
     for lib in libhs.libs {
         if lib.contains("hs") {
             println!("cargo:rustc-link-lib=static={}", lib);
         }
+    }
+
+    if cfg!(any(target_os = "macos", target_os = "freebsd")) {
+        println!("cargo:rustc-link-lib=dylib=c++");
+    } else {
+        println!("cargo:rustc-link-lib=dylib=stdc++");
+        println!("cargo:rustc-link-lib=dylib=gcc");
     }
 
     for link_path in libhs.link_paths {


### PR DESCRIPTION
And maybe on macOS, if https://github.com/rust-lang/rust/issues/44926 was the same issue. For some reason, the C++ library should be mentioned *after* everything.

(Note: the hyperscan package on FreeBSD is built without `-fPIC` by default, which prevents linking here. I'll send a patch to the ports collection to fix that.)