### PR TITLE
fix arm compile error

### DIFF
--- a/hyperscan/src/chimera/compile.rs
+++ b/hyperscan/src/chimera/compile.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 
 use anyhow::Error;
 use foreign_types::{ForeignType, ForeignTypeRef};
+use libc::c_char;
 
 use crate::chimera::{errors::AsCompileResult, ffi, Database, Pattern, Patterns};
 use crate::PlatformRef;
@@ -197,7 +198,7 @@ impl Builder for Pattern {
         platform: Option<&PlatformRef>,
     ) -> Result<Database, Self::Err> {
         let expr = CString::new(self.expression.as_str())?;
-        let ptr = expr.as_bytes_with_nul().as_ptr() as *const i8;
+        let ptr = expr.as_bytes_with_nul().as_ptr() as *const c_char;
         let flags = self.flags.bits();
         let mut db = MaybeUninit::uninit();
         let mut err = MaybeUninit::uninit();

--- a/hyperscan/src/common/serialized.rs
+++ b/hyperscan/src/common/serialized.rs
@@ -4,6 +4,7 @@ use std::mem::MaybeUninit;
 
 use anyhow::{Error, Result};
 use foreign_types::{ForeignType, ForeignTypeRef};
+use libc::c_char;
 use malloc_buf::Malloc;
 
 use crate::common::{Database, DatabaseRef};
@@ -57,7 +58,7 @@ impl<T: AsRef<[u8]>> Serialized for T {
         let mut db = MaybeUninit::uninit();
 
         unsafe {
-            ffi::hs_deserialize_database(buf.as_ptr() as *const i8, buf.len(), db.as_mut_ptr())
+            ffi::hs_deserialize_database(buf.as_ptr() as *const c_char, buf.len(), db.as_mut_ptr())
                 .map(|_| Database::from_ptr(db.assume_init()))
         }
     }
@@ -103,7 +104,7 @@ impl<T> DatabaseRef<T> {
     pub fn deserialize_at<B: AsRef<[u8]>>(&mut self, bytes: B) -> Result<()> {
         let bytes = bytes.as_ref();
 
-        unsafe { ffi::hs_deserialize_database_at(bytes.as_ptr() as *const i8, bytes.len(), self.as_ptr()).ok() }
+        unsafe { ffi::hs_deserialize_database_at(bytes.as_ptr() as *const c_char, bytes.len(), self.as_ptr()).ok() }
     }
 }
 

--- a/hyperscan/src/compile/builder.rs
+++ b/hyperscan/src/compile/builder.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 
 use anyhow::Error;
 use foreign_types::{ForeignType, ForeignTypeRef};
+use libc::c_char;
 
 use crate::common::{Database, Mode};
 use crate::compile::{AsCompileResult, Flags, Pattern, Patterns, PlatformRef};
@@ -93,7 +94,7 @@ impl Builder for Pattern {
 
         unsafe {
             ffi::hs_compile(
-                expr.as_bytes_with_nul().as_ptr() as *const i8,
+                expr.as_bytes_with_nul().as_ptr() as *const c_char,
                 self.flags.bits(),
                 mode,
                 platform.map_or_else(null_mut, ForeignTypeRef::as_ptr),

--- a/hyperscan/src/compile/expr.rs
+++ b/hyperscan/src/compile/expr.rs
@@ -8,6 +8,7 @@ use anyhow::{anyhow, bail, Error, Result};
 use bitflags::bitflags;
 use derive_more::{From, Into};
 use foreign_types::{foreign_type, ForeignType, ForeignTypeRef};
+use libc::c_char;
 
 use crate::compile::{AsCompileResult, Pattern};
 use crate::ffi;
@@ -303,7 +304,7 @@ impl Pattern {
 
         let info = unsafe {
             ffi::hs_expression_ext_info(
-                expr.as_ptr() as *const i8,
+                expr.as_ptr() as *const c_char,
                 self.flags.bits(),
                 &self.ext.0 as *const _,
                 info.as_mut_ptr(),

--- a/hyperscan/src/runtime/scan.rs
+++ b/hyperscan/src/runtime/scan.rs
@@ -4,7 +4,7 @@ use std::ptr;
 
 use anyhow::Result;
 use foreign_types::ForeignTypeRef;
-use libc::c_uint;
+use libc::{c_char, c_uint};
 
 use crate::common::{Block, DatabaseRef, Streaming, Vectored};
 use crate::errors::AsResult;
@@ -117,7 +117,7 @@ impl DatabaseRef<Block> {
 
             ffi::hs_scan(
                 self.as_ptr(),
-                data.as_ptr() as *const i8,
+                data.as_ptr() as *const c_char,
                 data.len() as u32,
                 0,
                 scratch.as_ptr(),
@@ -170,7 +170,7 @@ impl DatabaseRef<Vectored> {
 
             ffi::hs_scan_vector(
                 self.as_ptr(),
-                ptrs.as_slice().as_ptr() as *const *const i8,
+                ptrs.as_slice().as_ptr() as *const *const c_char,
                 lens.as_slice().as_ptr() as *const _,
                 ptrs.len() as u32,
                 0,
@@ -278,7 +278,7 @@ impl StreamRef {
 
             ffi::hs_scan_stream(
                 self.as_ptr(),
-                data.as_ptr() as *const i8,
+                data.as_ptr() as *const c_char,
                 data.len() as u32,
                 0,
                 scratch.as_ptr(),


### PR DESCRIPTION
Though Intel hasn't port hyperscan to arm architecture, Huawei has release a modified version hyperscan to fit arm architecture. On arm, there are some i8/u8 problems we are facing now:

```
1200error[E0308]: mismatched types
1201  --> /home/travis/.cargo/registry/src/github.com-1ecc6299db9ec823/hyperscan-0.2.0/src/common/serialized.rs:60:42
1202   |
120360 |             ffi::hs_deserialize_database(buf.as_ptr() as *const i8, buf.len(), db.as_mut_ptr())
1204   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
1205   |
1206   = note: expected raw pointer `*const u8`
1207              found raw pointer `*const i8`
```

So this pull request changes these u8/i8 into libc::c_char to fix these compile errors