### PR TITLE
Allow stdc++ to be statically linked

### DIFF
--- a/hyperscan-sys/Cargo.toml
+++ b/hyperscan-sys/Cargo.toml
@@ -21,6 +21,7 @@ gen = ["bindgen", "tracing"]
 runtime = []
 static = []
 tracing = []
+contained = ["static"]
 
 [dependencies]
 libc = "0.2"

--- a/hyperscan/Cargo.toml
+++ b/hyperscan/Cargo.toml
@@ -21,6 +21,7 @@ chimera = ["hyperscan-sys/chimera", "bitflags", "derive_more", "static"]
 compile = ["hyperscan-sys/compile", "bitflags", "derive_more"]
 full = ["compile", "runtime"]
 runtime = ["hyperscan-sys/runtime"]
+contained = ["hyperscan-sys/contained"]
 
 async = ["futures"]
 latest = ["v5_4"]


### PR DESCRIPTION
Add a feature called "contained" to allow static linking of stdc++.
This change allows libhs to be fully linked statically.
Without that change, stdc++ was always linked dynamically, bringing in glibc.
That feature allows compilation for different targets such as musl.