### PR TITLE
Add `bundled-vectorscan` feature

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "hyperscan-sys/bundled-vectorscan"]
+	path = hyperscan-sys/bundled-vectorscan
+	url = https://github.com/Vectorcamp/vectorscan

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +562,7 @@ dependencies = [
  "anyhow",
  "bindgen",
  "cargo-emit",
+ "cmake",
  "libc",
  "pkg-config",
 ]

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ features = ["runtime"]
 The `rust-hyperscan` library provides a `bundled-vectorscan` feature to build against a bundled version of the Vectorscan fork of Hyperscan. This fork supports architectures other than x86, including Apple Silicon. This feature requires several dependencies to be present in the build environment, including Python, CMake, Boost, and Ragel. If you have these dependencies, you can use the `bundled-vectorscan` feature:
 
 ```toml
-[dependencies.hyperscan[
-versino = "0.3"
+[dependencies.hyperscan]
+version = "0.3"
 features = ["bundled-vectorscan"]
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Usage
 
-To use, add the following line to Cargo.toml under [dependencies]:
+To use, add the following line to Cargo.toml under `[dependencies]`:
 
 ```toml
 hyperscan = "0.3"
@@ -91,6 +91,13 @@ As of version 0.2, `rust-hyperscan` uses dynamic library linking mode by default
 ```toml
 [dependencies]
 hyperscan = { version = "0.3", features = ["static"] }
+```
+
+Additionally, on macOS, a `contained` feature is supported, which additionally ensures that `libc++` is statically linked:
+
+```toml
+[dependencies]
+hyperscan = { version = "0.3", features = ["contained"] }
 ```
 
 ### Hyperscan Runtime

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Starting with Hyperscan v5.0, several new APIs and flags have been introduced.
 
 `rust-hyperscan` uses the latest version of the API by default, providing new features such as `Literal`.
 
-If you want to work with Hyperscan v4.x, you can disable `v5` feature at compile time.
+If you want to work with Hyperscan v4.x, you can disable the `v5` feature at compile time:
 
 ```toml
 [dependencies.hyperscan]
@@ -55,7 +55,7 @@ features = ["full"]
 
 In order to improve regular expression compatibility, Hyperscan v5.0 starts to provide a PCRE-compatible [Chimera](http://intel.github.io/hyperscan/dev-reference/chimera.html) library.
 
-To enable `Chimera` support, you need to manually download PCRE 8.41 or above, unzip to the source directory of Hyperscan 5.x, compile and install it.
+To enable `Chimera` support, you need to manually download PCRE 8.41 or above, unzip to the source directory of Hyperscan 5.x, compile and install it:
 
 ```bash
 $ cd hyperscan-5.4.0
@@ -69,24 +69,24 @@ $ ninja
 $ ninja install
 ```
 
-Then point to the hyperscan installation directory with the `PKG_CONFIG_PATH` environment variable and enable `chimera` feature.
+Then point to the hyperscan installation directory with the `PKG_CONFIG_PATH` environment variable and enable `chimera` feature:
 
 ```bash
 $ PKG_CONFIG_PATH=<CMAKE_INSTALL_PREFIX>/lib/pkgconfig cargo build
 ```
 
-The `chimera` feature should be enabled.
+Finally, enable the `chimera` feature:
 
 ```toml
 [dependencies]
 hyperscan = { version = "0.3", features = ["chimera"] }
 ```
 
-Note: The `Chimera` library does not support dynamic library linking mode, `static` feature is automatically enabled when `chimera` is enabled.
+Note: The `Chimera` library does not support dynamic library linking mode; the `static` feature is automatically enabled when `chimera` is enabled.
 
 ### Static Linking Mode
 
-As of version 0.2, `rust-hyperscan` uses dynamic library linking mode by default. If you need link a static library, you can use the `static` feature.
+As of version 0.2, `rust-hyperscan` uses dynamic library linking mode by default. If you need link a static library, you can use the `static` feature:
 
 ```toml
 [dependencies]
@@ -95,7 +95,7 @@ hyperscan = { version = "0.3", features = ["static"] }
 
 ### Hyperscan Runtime
 
-Hyperscan provides [a standalone runtime library](http://intel.github.io/hyperscan/dev-reference/serialization.html#the-runtime-library), which can be used separately. If you don't need to compile regular expressions at runtime, you can reduce the size of the executable using `runtime` mode and get rid of C++ dependencies.
+Hyperscan provides [a standalone runtime library](http://intel.github.io/hyperscan/dev-reference/serialization.html#the-runtime-library), which can be used separately. If you don't need to compile regular expressions at runtime, you can reduce the size of the executable using `runtime` feature and getting rid of C++ dependencies:
 
 ```toml
 [dependencies.hyperscan]
@@ -103,6 +103,17 @@ version = "0.3"
 default-features = false
 features = ["runtime"]
 ```
+
+### Use a bundled version of the [`vectorscan`](https://github.com/Vectorcamp/vectorscan) fork of Hyperscan
+
+The `rust-hyperscan` library provides a `bundled-vectorscan` feature to build against a bundled version of the Vectorscan fork of Hyperscan. This fork supports architectures other than x86, including Apple Silicon. This feature requires several dependencies to be present in the build environment, including Python, CMake, Boost, and Ragel. If you have these dependencies, you can use the `bundled-vectorscan` feature:
+
+```toml
+[dependencies.hyperscan[
+versino = "0.3"
+features = ["bundled-vectorscan"]
+```
+
 
 ## Benchmark
 

--- a/hyperscan-sys/Cargo.toml
+++ b/hyperscan-sys/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/flier/rust-hyperscan"
 version = "0.3.2"
 
 [features]
+bundled-vectorscan = ["static", "cmake"]
 chimera = ["static"]
 compile = []
 contained = ["static"]
@@ -29,6 +30,7 @@ libc = "0.2"
 
 [build-dependencies]
 anyhow = "1"
+cmake = {version = "0.1", optional = true}
 cargo-emit = "0.2"
 pkg-config = "0.3"
 

--- a/hyperscan/Cargo.toml
+++ b/hyperscan/Cargo.toml
@@ -18,6 +18,8 @@ docsrs = ["hyperscan-sys/docsrs", "full", "latest", "async", "chimera"]
 gen = ["hyperscan-sys/gen"]
 static = ["hyperscan-sys/static"]
 
+bundled-vectorscan = ["hyperscan-sys/bundled-vectorscan", "static"]
+
 chimera = ["hyperscan-sys/chimera", "bitflags", "derive_more", "static"]
 compile = ["hyperscan-sys/compile", "bitflags", "derive_more"]
 contained = ["hyperscan-sys/contained"]


### PR DESCRIPTION
The new `bundled-vectorscan` feature addresses #20, allowing `rust-hyperscan` to build and run on non-Intel architectures, including Apple Silicon. The way this feature works is to build against a bundled version of the [vectorscan](https://github.com/Vectorcamp/vectorscan) fork of Hyperscan, which supports additional architectures but keeps the same API.

This feature is not enabled by default. The bundled version of vectorscan is added via a Git submodule.

Building vectorscan (or hyperscan) from source requires several build-time dependencies, including Boost, CMake, Ragel, and Python. Isolating the vectorscan (or hyperscan) code to eliminate these dependencies would be significantly more work.

I also updated the README to describe this new feature, as well as expanding slightly on the existing features.