### PR TITLE
Make `Match`, `Matches`, `Split` and `SplitN` accessible

### DIFF
--- a/hyperscan/src/regex/mod.rs
+++ b/hyperscan/src/regex/mod.rs
@@ -3,4 +3,4 @@ mod builder;
 mod re;
 
 pub use builder::{RegexBuilder, RegexSetBuilder};
-pub use re::Regex;
+pub use re::{Regex, Match, Matches, Split, SplitN};


### PR DESCRIPTION
The Regex compatible interface does not provide access to  the types mentioned above, but it should. This PR fixes that.